### PR TITLE
show arm in the list of ARCH just as in the Makefile

### DIFF
--- a/demos/m2/v6-v7/Demo_Commands.txt
+++ b/demos/m2/v6-v7/Demo_Commands.txt
@@ -21,7 +21,7 @@ Below are the instructions use for the C1M2V6 Demo
 
  Overrides:
       CPU= - Can be set to differnet ARM processors  [cortex-m0plus, cortex-m4]
-      ARCH= - Can be set to different ARM architectures [armv7e-m, thumb, etc]
+      ARCH= - Can be set to different ARM architectures [arm, thumb, etc]
       SPECS= - Can be set to different specs files [nosys.specs, nano.specs]	
 
 =============================================================================


### PR DESCRIPTION
arm-none-eabi-gcc -c main.c -mcpu=cortex-m4 -marmv7e-m --specs=nosys.specs -Wall -o main.o
arm-none-eabi-gcc: error: unrecognized command line option '-marmv7e-m'; did you mean '-march=armv7e-m'?
Makefile:50: recipe for target 'main.o' failed
make: *** [main.o] Error 1
